### PR TITLE
feat(timer middleware): change non warning timing log to Debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [_vNext_](https://github.com/sketch7/FluentlyHttpClient/compare/3.6.0...3.7.0) (2019-X-X)
 
+## [3.7.2](https://github.com/sketch7/FluentlyHttpClient/compare/3.7.1...3.7.2) (2019-10-08)
+
+### Bug Fixes
+
+- **timer middleware:** change non warning timing log to `Debug` instead of `Info` (as it was too spammy especially when used with `LoggerMiddleware`)
+
 ## [3.7.1](https://github.com/sketch7/FluentlyHttpClient/compare/3.7.0...3.7.1) (2019-10-07)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sketch7/fluently-http-client",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "versionSuffix": "",
   "scripts": {
     "pack": "bash ./tools/pack.sh",

--- a/src/FluentlyHttpClient/GraphQL/GqlQuery.cs
+++ b/src/FluentlyHttpClient/GraphQL/GqlQuery.cs
@@ -3,7 +3,7 @@
 	/// <summary>
 	/// Request object for GraphQL requests.
 	/// </summary>
-	public class GqlQuery
+	public class GqlQuery // deprecated: rename to GqlRequest or GqlRequestPayload?
 	{
 		/// <summary>
 		/// Gets or sets GraphQL query.

--- a/src/FluentlyHttpClient/Middleware/TimerHttpMiddleware.cs
+++ b/src/FluentlyHttpClient/Middleware/TimerHttpMiddleware.cs
@@ -62,8 +62,8 @@ namespace FluentlyHttpClient.Middleware
 
 				if (_logger.IsEnabled(LogLevel.Warning) && watch.Elapsed > threshold)
 					_logger.LogWarning(TimeTakenMessage, request, watch.ElapsedMilliseconds);
-				else if (_logger.IsEnabled(LogLevel.Information))
-					_logger.LogInformation(TimeTakenMessage, request, watch.ElapsedMilliseconds);
+				else if (_logger.IsEnabled(LogLevel.Debug))
+					_logger.LogDebug(TimeTakenMessage, request, watch.ElapsedMilliseconds);
 			}
 
 			return response.SetTimeTaken(watch.Elapsed);


### PR DESCRIPTION
instead of `Info` (as it was too spammy especially when used with `LoggerMiddleware`)