### PR TITLE
refactor(tests): use Shouldly for assertions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.1" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <!-- 3rd party -->
@@ -26,6 +26,7 @@
     <PackageVersion Include="Sketch7.Core" Version="0.2.0" />
     <!-- testing -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <!-- testing -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/src/FluentlyHttpClient/Middleware/FluentHttpMiddlewareBuilder.cs
+++ b/src/FluentlyHttpClient/Middleware/FluentHttpMiddlewareBuilder.cs
@@ -93,7 +93,7 @@ public class FluentHttpMiddlewareBuilder
 				}
 			}
 			else
-				ctor = new object[] { };
+				ctor = [];
 			var instance = (IFluentHttpMiddleware)ActivatorUtilities.CreateInstance(_serviceProvider, pipe.Type, ctor);
 
 			if (isFirst)

--- a/test/FluentHttpClientFactoryTest.cs
+++ b/test/FluentHttpClientFactoryTest.cs
@@ -13,7 +13,7 @@ public class ClientFactoryTest_Build
 		var httpClient = GetNewClientFactory().CreateBuilder("abc")
 			.Build();
 
-		Assert.Null(httpClient.BaseUrl);
+		httpClient.BaseUrl.ShouldBeNull();
 	}
 }
 
@@ -30,7 +30,7 @@ public class ClientFactory_WithRequestBuilderDefaults
 			.GetRequiredService<IFluentHttpClientFactory>();
 
 		var client = f.CreateBuilder("sketch7").Build();
-		Assert.Equal("default-config", client.Headers.UserAgent.ToString());
+		client.Headers.UserAgent.ToString().ShouldBe("default-config");
 	}
 
 
@@ -57,17 +57,13 @@ public class ClientFactory_WithRequestBuilderDefaults
 		httpClientB.Headers.TryGetValues("X-S7", out var s7HeadersB);
 		httpClientA.Headers.TryGetValues("X-Org", out var orgHeadersB);
 
-		Assert.NotNull(orgHeadersA);
-		Assert.Single(orgHeadersA, "s7");
-		Assert.NotNull(s7HeadersA);
-		Assert.Single(s7HeadersA, "a");
-		Assert.Equal("dXNlcjpwYSQk", httpClientA.Headers.Authorization!.Parameter);
+		orgHeadersA.ShouldNotBeNull().ShouldHaveSingleItem().ShouldBe("s7");
+		s7HeadersA.ShouldNotBeNull().ShouldHaveSingleItem().ShouldBe("a");
+		httpClientA.Headers.Authorization!.Parameter.ShouldBe("dXNlcjpwYSQk");
 
-		Assert.NotNull(orgHeadersB);
-		Assert.Single(orgHeadersB, "s7");
-		Assert.NotNull(s7HeadersB);
-		Assert.Single(s7HeadersB, "b");
-		Assert.Equal("dXNlci0yOnBhJCQ=", httpClientB.Headers.Authorization!.Parameter);
+		orgHeadersB.ShouldNotBeNull().ShouldHaveSingleItem().ShouldBe("s7");
+		s7HeadersB.ShouldNotBeNull().ShouldHaveSingleItem().ShouldBe("b");
+		httpClientB.Headers.Authorization!.Parameter.ShouldBe("dXNlci0yOnBhJCQ=");
 	}
 
 	[Fact]
@@ -81,8 +77,8 @@ public class ClientFactory_WithRequestBuilderDefaults
 		var request = httpClient.CreateRequest("/api")
 			.Build();
 
-		Assert.NotNull(request);
-		Assert.Equal(HttpMethod.Put, request.Method);
+		request.ShouldNotBeNull();
+		request.Method.ShouldBe(HttpMethod.Put);
 	}
 
 	[Fact]
@@ -97,9 +93,9 @@ public class ClientFactory_WithRequestBuilderDefaults
 		var request = httpClient.CreateRequest("/api")
 			.Build();
 
-		Assert.NotNull(request);
-		Assert.Equal(HttpMethod.Put, request.Method);
-		Assert.Equal("user", request.Items["context"]);
+		request.ShouldNotBeNull();
+		request.Method.ShouldBe(HttpMethod.Put);
+		request.Items["context"].ShouldBe("user");
 	}
 
 	[Fact]
@@ -114,9 +110,9 @@ public class ClientFactory_WithRequestBuilderDefaults
 		var request = httpClient.CreateRequest("/api")
 			.Build();
 
-		Assert.NotNull(request);
-		Assert.Equal(HttpMethod.Get, request.Method);
-		Assert.Equal("user", request.Items["context"]);
+		request.ShouldNotBeNull();
+		request.Method.ShouldBe(HttpMethod.Get);
+		request.Items["context"].ShouldBe("user");
 	}
 
 	[Fact]
@@ -140,7 +136,7 @@ public class ClientFactory_WithRequestBuilderDefaults
 			})
 			.Build();
 
-		Assert.Equal("/api/heroes?ROLES=warrior,assassin", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/api/heroes?ROLES=warrior,assassin");
 	}
 
 	[Fact]
@@ -158,8 +154,8 @@ public class ClientFactory_WithRequestBuilderDefaults
 				.Build()
 			;
 
-		Assert.Equal("http://abc.com/v1/", subHttpClient.BaseUrl);
-		Assert.Equal("http://abc.com/", httpClient.BaseUrl);
+		subHttpClient.BaseUrl.ShouldBe("http://abc.com/v1/");
+		httpClient.BaseUrl.ShouldBe("http://abc.com/");
 	}
 }
 
@@ -173,7 +169,7 @@ public class ClientFactory_ConfigureFormatters
 			.ConfigureFormatters(opts => { opts.Formatters.Clear(); })
 			.Build();
 
-		Assert.Empty(httpClient.Formatters);
+		httpClient.Formatters.ShouldBeEmpty();
 	}
 
 	[Fact]
@@ -187,7 +183,7 @@ public class ClientFactory_ConfigureFormatters
 			})
 			.Build();
 
-		Assert.Equal(httpClient.Formatters.XmlFormatter, httpClient.DefaultFormatter);
+		httpClient.DefaultFormatter.ShouldBe(httpClient.Formatters.XmlFormatter);
 	}
 
 	[Fact]
@@ -207,8 +203,8 @@ public class ClientFactory_ConfigureFormatters
 				.Build()
 			;
 
-		Assert.Equal(httpClient.Formatters.XmlFormatter, httpClient.DefaultFormatter);
-		Assert.Equal(httpClient2.Formatters.FormUrlEncodedFormatter, httpClient2.DefaultFormatter);
+		httpClient.DefaultFormatter.ShouldBe(httpClient.Formatters.XmlFormatter);
+		httpClient2.DefaultFormatter.ShouldBe(httpClient2.Formatters.FormUrlEncodedFormatter);
 	}
 
 	[Fact]
@@ -224,7 +220,7 @@ public class ClientFactory_ConfigureFormatters
 			})
 			.Build();
 
-		Assert.Equal(jsonFormatter, httpClient.DefaultFormatter);
+		httpClient.DefaultFormatter.ShouldBe(jsonFormatter);
 	}
 
 	[Fact]
@@ -238,7 +234,7 @@ public class ClientFactory_ConfigureFormatters
 			})
 			.Build();
 
-		Assert.Equal(httpClient.Formatters.First(), httpClient.DefaultFormatter);
+		httpClient.DefaultFormatter.ShouldBe(httpClient.Formatters.First());
 	}
 }
 
@@ -253,8 +249,7 @@ public class ClientFactory_WithConfigureDefaults
 			.WithBaseUrl("http://abc.com")
 			.Build();
 
-		var userAgentHeader = httpClient.Headers.GetValues("User-Agent").FirstOrDefault();
-		Assert.Equal("hots", userAgentHeader);
+		httpClient.Headers.GetValues("User-Agent").FirstOrDefault().ShouldBe("hots");
 	}
 }
 
@@ -267,15 +262,15 @@ public class ClientFactory_Register
 			.WithBaseUrl("http://abc.com")
 			.Build();
 
-		Assert.NotNull(httpClient);
-		Assert.Equal("abc", httpClient.Identifier);
+		httpClient.ShouldNotBeNull();
+		httpClient.Identifier.ShouldBe("abc");
 	}
 
 	[Fact]
 	public void ThrowsErrorWhenIdentifierNotSpecified()
 	{
 		var clientBuilder = GetNewClientFactory().CreateBuilder(null!);
-		Assert.Throws<ClientBuilderValidationException>(() => clientBuilder.Register());
+		Should.Throw<ClientBuilderValidationException>(() => clientBuilder.Register());
 	}
 
 	[Fact]
@@ -285,7 +280,7 @@ public class ClientFactory_Register
 			.WithBaseUrl("http://abc.com")
 			.Register();
 
-		Assert.Throws<ClientBuilderValidationException>(() => clientBuilder.Register());
+		Should.Throw<ClientBuilderValidationException>(() => clientBuilder.Register());
 	}
 }
 
@@ -302,7 +297,7 @@ public class ClientFactory_Remove
 		var isRegistered = fluentHttpClientFactory.Remove("abc")
 			.Has("abc");
 
-		await Assert.ThrowsAsync<ObjectDisposedException>(() => httpClient.Get<Hero>("/api/heroes/azmodan"));
-		Assert.False(isRegistered);
+		await Should.ThrowAsync<ObjectDisposedException>(() => httpClient.Get<Hero>("/api/heroes/azmodan"));
+		isRegistered.ShouldBeFalse();
 	}
 }

--- a/test/FluentHttpClientTest.cs
+++ b/test/FluentHttpClientTest.cs
@@ -23,8 +23,8 @@ public class HttpClient
 
 		var hero = await httpClient.Get<Hero>("/api/heroes/azmodan");
 
-		Assert.NotNull(hero);
-		Assert.Equal("Azmodan", hero.Name);
+		hero.ShouldNotBeNull();
+		hero.Name.ShouldBe("Azmodan");
 	}
 
 	[Fact]
@@ -51,8 +51,8 @@ public class HttpClient
 			Title = "Lord of Sin"
 		});
 
-		Assert.NotNull(hero);
-		Assert.Equal("Lord of Sin", hero.Title);
+		hero.ShouldNotBeNull();
+		hero.Title.ShouldBe("Lord of Sin");
 	}
 
 	[Fact]
@@ -92,21 +92,21 @@ public class HttpClient
 		httpClient.Headers.TryGetValues("country", out var countryValues);
 		var subClientCountry = subClient.Headers.GetValues("country").FirstOrDefault();
 
-		Assert.Equal("sketch7", httpClient.Identifier);
-		Assert.Equal("sketch7.subclient", subClient.Identifier);
-		Assert.Equal("en-GB", httpClientLocale);
-		Assert.Equal("de", subClientLocale);
-		Assert.Null(countryValues?.FirstOrDefault());
-		Assert.Equal("de", subClientCountry);
+		httpClient.Identifier.ShouldBe("sketch7");
+		subClient.Identifier.ShouldBe("sketch7.subclient");
+		httpClientLocale.ShouldBe("en-GB");
+		subClientLocale.ShouldBe("de");
+		countryValues?.FirstOrDefault().ShouldBeNull();
+		subClientCountry.ShouldBe("de");
 
-		Assert.Equal(httpClientRequest.HttpMethod, subClientRequest.HttpMethod);
-		Assert.Equal(httpClientRequest.Items["error-mapping"], subClientRequest.Items["error-mapping"]);
-		Assert.Equal("user", httpClientRequest.Items["context"]);
-		Assert.Equal("reward", subClientRequest.Items["context"]);
-		Assert.Equal(httpClient.Formatters.Count, subClient.Formatters.Count);
+		subClientRequest.HttpMethod.ShouldBe(httpClientRequest.HttpMethod);
+		subClientRequest.Items["error-mapping"].ShouldBe(httpClientRequest.Items["error-mapping"]);
+		httpClientRequest.Items["context"].ShouldBe("user");
+		subClientRequest.Items["context"].ShouldBe("reward");
+		subClient.Formatters.Count.ShouldBe(httpClient.Formatters.Count);
 		// todo: check middleware count?
 
-		Assert.Equal(2, httpClientFactory.Count);
+		httpClientFactory.Count.ShouldBe(2);
 	}
 
 	[Fact]
@@ -136,8 +136,8 @@ public class HttpClient
 		var response = await httpClient.CreateGqlRequest(query, operationName)
 			.ReturnAsGqlResponse<Hero>();
 
-		Assert.True(response.IsSuccessStatusCode);
-		Assert.NotNull(response.Data);
-		Assert.Equal("Lord of Sin", response.Data.Title);
+		response.IsSuccessStatusCode.ShouldBeTrue();
+		response.Data.ShouldNotBeNull();
+		response.Data.Title.ShouldBe("Lord of Sin");
 	}
 }

--- a/test/FluentHttpHeadersTest.cs
+++ b/test/FluentHttpHeadersTest.cs
@@ -11,7 +11,7 @@ public class FluentHttpHeaders_Tests
 	{
 		var headers = new FluentHttpHeaders
 		{
-			{HeaderTypes.Accept, new[] {"json", "msgpack"}}
+			{HeaderTypes.Accept, ["json", "msgpack"] }
 		};
 
 		var dictionary = headers.ToDictionary();
@@ -28,9 +28,9 @@ public class FluentHttpHeaders_Tests
 	{
 		var headers = new FluentHttpHeaders
 		{
-			{HeaderTypes.Authorization, new[]{"the-xx"}},
-			{HeaderTypes.Accept, new[] {"json", "msgpack"}},
-			{HeaderTypes.XForwardedHost, new[] {"sketch7.com"}},
+			{HeaderTypes.Authorization, ["the-xx"] },
+			{HeaderTypes.Accept, ["json", "msgpack"] },
+			{HeaderTypes.XForwardedHost, ["sketch7.com"] },
 		};
 
 		var headersJson = JsonConvert.SerializeObject(headers);
@@ -62,9 +62,8 @@ public class FluentHttpHeaders_Add
 	[Fact]
 	public void ShouldAdd()
 	{
-		var headers = new FluentHttpHeaders();
+		var headers = new FluentHttpHeaders { { HeaderTypes.Authorization, "the-xx" } };
 
-		headers.Add(HeaderTypes.Authorization, "the-xx");
 		headers.Authorization.ShouldBe("the-xx");
 	}
 
@@ -83,9 +82,9 @@ public class FluentHttpHeaders_Add
 	{
 		var headers = new FluentHttpHeaders
 		{
-			{ HeaderTypes.Accept, new[] { "json", "msgpack" } }
+			{ HeaderTypes.Accept, ["json", "msgpack"] }
 		};
-		headers.Accept.ShouldBe("json,msgpack");
+		((string?)headers.Accept).ShouldBe("json,msgpack");
 	}
 
 	[Fact]
@@ -110,7 +109,7 @@ public class FluentHttpHeaders_Add
 		headers.SetRange(new Dictionary<string, StringValues>{
 			{HeaderTypes.Accept, "xml"}
 		});
-		headers.Accept.ShouldBe("xml");
+		((string?)headers.Accept).ShouldBe("xml");
 	}
 }
 
@@ -165,8 +164,8 @@ public class FluentHttpHeaders_Accessors
 	public void GetExists_ShouldReturn()
 	{
 		var headers = new FluentHttpHeaders()
-			.Add(HeaderTypes.Accept, new[] { "json", "msgpack" });
-		headers.Accept.ShouldBe("json,msgpack");
+			.Add(HeaderTypes.Accept, ["json", "msgpack"]);
+		((string?)headers.Accept).ShouldBe("json,msgpack");
 	}
 
 	[Fact]
@@ -176,7 +175,7 @@ public class FluentHttpHeaders_Accessors
 		{
 			Accept = new[] { "json", "msgpack" }
 		};
-		headers.Accept.ShouldBe("json,msgpack");
+		((string?)headers.Accept).ShouldBe("json,msgpack");
 	}
 
 	[Fact]
@@ -187,7 +186,7 @@ public class FluentHttpHeaders_Accessors
 			Accept = new[] { "json", "msgpack" }
 		};
 		headers.Accept = "json";
-		headers.Accept.ShouldBe("json");
+		((string?)headers.Accept).ShouldBe("json");
 	}
 }
 
@@ -228,13 +227,13 @@ public class FluentHttpHeaders_Initialize
 	{
 		var headersMap = new Dictionary<string, IEnumerable<string>>
 		{
-			{HeaderTypes.Accept, new[] {"json", "msgpack"} },
-			{HeaderTypes.XForwardedFor, new[] {"192.168.1.1", "127.0.0.1"} },
+			{HeaderTypes.Accept, ["json", "msgpack"] },
+			{HeaderTypes.XForwardedFor, ["192.168.1.1", "127.0.0.1"] },
 		};
 
 		var headers = new FluentHttpHeaders(headersMap);
-		headers.Accept.ShouldBe("json,msgpack");
-		headers.XForwardedFor.ShouldBe("192.168.1.1,127.0.0.1");
+		((string?)headers.Accept).ShouldBe("json,msgpack");
+		((string?)headers.XForwardedFor).ShouldBe("192.168.1.1,127.0.0.1");
 		headers.Count.ShouldBe(headersMap.Count);
 	}
 
@@ -243,11 +242,11 @@ public class FluentHttpHeaders_Initialize
 	{
 		var httpHeaders = new HttpRequestMessage().Headers;
 		httpHeaders.Add(HeaderTypes.Authorization, "the-xx");
-		httpHeaders.Add(HeaderTypes.XForwardedFor, new[] { "192.168.1.1", "127.0.0.1" });
+		httpHeaders.Add(HeaderTypes.XForwardedFor, ["192.168.1.1", "127.0.0.1"]);
 
 		var headers = new FluentHttpHeaders(httpHeaders);
 		headers.Authorization.ShouldBe("the-xx");
-		headers.XForwardedFor.ShouldBe("192.168.1.1,127.0.0.1");
+		((string?)headers.XForwardedFor).ShouldBe("192.168.1.1,127.0.0.1");
 		headers.Count.ShouldBe(2);
 	}
 }
@@ -273,7 +272,7 @@ public class FluentHttpHeaders_ToHashString
 		var headers = new FluentHttpHeaders
 		{
 			{HeaderTypes.Authorization, "the-xx"},
-			{HeaderTypes.Accept, new[] {"json", "msgpack"}}
+			{HeaderTypes.Accept, ["json", "msgpack"] }
 		};
 		var hash = headers.ToHashString();
 
@@ -286,7 +285,7 @@ public class FluentHttpHeaders_ToHashString
 		var headers = new FluentHttpHeaders
 			{
 				{HeaderTypes.Authorization, "the-xx"},
-				{HeaderTypes.Accept, new[] {"json", "msgpack"}},
+				{HeaderTypes.Accept, ["json", "msgpack"] },
 				{HeaderTypes.XForwardedHost, "sketch7.com"},
 			}
 			.WithOptions(opts => opts.WithHashingExclude(pair => pair.Key == HeaderTypes.Authorization));

--- a/test/FluentHttpHeadersTest.cs
+++ b/test/FluentHttpHeadersTest.cs
@@ -17,10 +17,10 @@ public class FluentHttpHeaders_Tests
 		var dictionary = headers.ToDictionary();
 
 		var result = dictionary.GetValueOrDefault(HeaderTypes.Accept);
-		Assert.NotNull(result);
-		Assert.Equal(2, result.Length);
-		Assert.Equal("json", result[0]);
-		Assert.Equal("msgpack", result[1]);
+		result.ShouldNotBeNull();
+		result.Length.ShouldBe(2);
+		result[0].ShouldBe("json");
+		result[1].ShouldBe("msgpack");
 	}
 
 	[Fact]
@@ -36,23 +36,16 @@ public class FluentHttpHeaders_Tests
 		var headersJson = JsonConvert.SerializeObject(headers);
 		var headersCopied = JsonConvert.DeserializeObject<FluentHttpHeaders>(headersJson);
 
-		Assert.NotNull(headersCopied);
-		Assert.Collection(headersCopied, x =>
-			{
-				Assert.Equal(HeaderTypes.Authorization, x.Key);
-				Assert.Equal("the-xx", x.Value![0]);
-			},
-			x =>
-			{
-				Assert.Equal(HeaderTypes.Accept, x.Key);
-				Assert.Equal("json,msgpack", string.Join(",", x.Value!));
-			},
-			x =>
-			{
-				Assert.Equal(HeaderTypes.XForwardedHost, x.Key);
-				Assert.Equal("sketch7.com", x.Value![0]);
-			});
-		Assert.Equal("the-xx", headersCopied.Authorization);
+		headersCopied.ShouldNotBeNull();
+		headersCopied.Count.ShouldBe(3);
+		var items = headersCopied.ToList();
+		items[0].Key.ShouldBe(HeaderTypes.Authorization);
+		items[0].Value![0].ShouldBe("the-xx");
+		items[1].Key.ShouldBe(HeaderTypes.Accept);
+		string.Join(",", items[1].Value!).ShouldBe("json,msgpack");
+		items[2].Key.ShouldBe(HeaderTypes.XForwardedHost);
+		items[2].Value![0].ShouldBe("sketch7.com");
+		headersCopied.Authorization.ShouldBe("the-xx");
 	}
 
 	[Fact]
@@ -60,7 +53,7 @@ public class FluentHttpHeaders_Tests
 	{
 		var headers = new FluentHttpHeaders()
 			.WithUserAgent("leoric");
-		Assert.Equal("leoric", headers.UserAgent);
+		headers.UserAgent.ShouldBe("leoric");
 	}
 }
 
@@ -72,7 +65,7 @@ public class FluentHttpHeaders_Add
 		var headers = new FluentHttpHeaders();
 
 		headers.Add(HeaderTypes.Authorization, "the-xx");
-		Assert.Equal("the-xx", headers.Authorization);
+		headers.Authorization.ShouldBe("the-xx");
 	}
 
 	[Fact]
@@ -82,7 +75,7 @@ public class FluentHttpHeaders_Add
 
 		StringValues str = new[] { "the-xx", "supersecret" };
 		headers.Add(HeaderTypes.Authorization, str);
-		Assert.Equal("the-xx,supersecret", headers.Authorization);
+		headers.Authorization.ShouldBe("the-xx,supersecret");
 	}
 
 	[Fact]
@@ -92,7 +85,7 @@ public class FluentHttpHeaders_Add
 		{
 			{ HeaderTypes.Accept, new[] { "json", "msgpack" } }
 		};
-		Assert.Equal("json,msgpack", headers.Accept);
+		headers.Accept.ShouldBe("json,msgpack");
 	}
 
 	[Fact]
@@ -102,7 +95,7 @@ public class FluentHttpHeaders_Add
 		headers.AddRange(new Dictionary<string, StringValues>{
 			{HeaderTypes.Accept, new[] {"json", "msgpack"}}
 		});
-		Assert.Throws<ArgumentException>(() => headers.AddRange(new Dictionary<string, StringValues>{
+		Should.Throw<ArgumentException>(() => headers.AddRange(new Dictionary<string, StringValues>{
 			{HeaderTypes.Accept, "xml"}
 		}));
 	}
@@ -117,7 +110,7 @@ public class FluentHttpHeaders_Add
 		headers.SetRange(new Dictionary<string, StringValues>{
 			{HeaderTypes.Accept, "xml"}
 		});
-		Assert.Equal("xml", headers.Accept);
+		headers.Accept.ShouldBe("xml");
 	}
 }
 
@@ -131,7 +124,7 @@ public class FluentHttpHeaders_Remove
 			{ HeaderTypes.Authorization, "the-xx" }
 		};
 		headers.Remove(HeaderTypes.Authorization);
-		Assert.Null(headers.Authorization);
+		headers.Authorization.ShouldBeNull();
 	}
 
 	[Fact]
@@ -139,7 +132,7 @@ public class FluentHttpHeaders_Remove
 	{
 		var headers = new FluentHttpHeaders();
 		headers.Remove(HeaderTypes.Authorization);
-		Assert.Null(headers.Authorization);
+		headers.Authorization.ShouldBeNull();
 	}
 }
 
@@ -154,8 +147,8 @@ public class FluentHttpHeaders_GetValue
 		};
 		var value = headers.GetValue("X-Custom");
 		var value2 = headers.GetValue("x-custom");
-		Assert.Equal("the-xx", value);
-		Assert.Equal("the-xx", value2);
+		value.ShouldBe("the-xx");
+		value2.ShouldBe("the-xx");
 	}
 }
 
@@ -165,7 +158,7 @@ public class FluentHttpHeaders_Accessors
 	public void GetNotExists_ShouldReturnNull()
 	{
 		var headers = new FluentHttpHeaders();
-		Assert.Null(headers.UserAgent);
+		headers.UserAgent.ShouldBeNull();
 	}
 
 	[Fact]
@@ -173,7 +166,7 @@ public class FluentHttpHeaders_Accessors
 	{
 		var headers = new FluentHttpHeaders()
 			.Add(HeaderTypes.Accept, new[] { "json", "msgpack" });
-		Assert.Equal("json,msgpack", headers.Accept);
+		headers.Accept.ShouldBe("json,msgpack");
 	}
 
 	[Fact]
@@ -183,7 +176,7 @@ public class FluentHttpHeaders_Accessors
 		{
 			Accept = new[] { "json", "msgpack" }
 		};
-		Assert.Equal("json,msgpack", headers.Accept);
+		headers.Accept.ShouldBe("json,msgpack");
 	}
 
 	[Fact]
@@ -194,7 +187,7 @@ public class FluentHttpHeaders_Accessors
 			Accept = new[] { "json", "msgpack" }
 		};
 		headers.Accept = "json";
-		Assert.Equal("json", headers.Accept);
+		headers.Accept.ShouldBe("json");
 	}
 }
 
@@ -210,9 +203,9 @@ public class FluentHttpHeaders_Initialize
 		};
 
 		var headers = new FluentHttpHeaders(headersMap);
-		Assert.Equal("the-xx", headers.Authorization);
-		Assert.Equal("json", headers.ContentType);
-		Assert.Equal(headersMap.Count, headers.Count);
+		headers.Authorization.ShouldBe("the-xx");
+		headers.ContentType.ShouldBe("json");
+		headers.Count.ShouldBe(headersMap.Count);
 	}
 
 	[Fact]
@@ -225,9 +218,9 @@ public class FluentHttpHeaders_Initialize
 		};
 
 		var headers = new FluentHttpHeaders(headersMap);
-		Assert.Equal("the-xx", headers.Authorization);
-		Assert.Equal("json", headers.ContentType);
-		Assert.Equal(headersMap.Count, headers.Count);
+		headers.Authorization.ShouldBe("the-xx");
+		headers.ContentType.ShouldBe("json");
+		headers.Count.ShouldBe(headersMap.Count);
 	}
 
 	[Fact]
@@ -240,9 +233,9 @@ public class FluentHttpHeaders_Initialize
 		};
 
 		var headers = new FluentHttpHeaders(headersMap);
-		Assert.Equal("json,msgpack", headers.Accept);
-		Assert.Equal("192.168.1.1,127.0.0.1", headers.XForwardedFor);
-		Assert.Equal(headersMap.Count, headers.Count);
+		headers.Accept.ShouldBe("json,msgpack");
+		headers.XForwardedFor.ShouldBe("192.168.1.1,127.0.0.1");
+		headers.Count.ShouldBe(headersMap.Count);
 	}
 
 	[Fact]
@@ -253,9 +246,9 @@ public class FluentHttpHeaders_Initialize
 		httpHeaders.Add(HeaderTypes.XForwardedFor, new[] { "192.168.1.1", "127.0.0.1" });
 
 		var headers = new FluentHttpHeaders(httpHeaders);
-		Assert.Equal("the-xx", headers.Authorization);
-		Assert.Equal("192.168.1.1,127.0.0.1", headers.XForwardedFor);
-		Assert.Equal(2, headers.Count);
+		headers.Authorization.ShouldBe("the-xx");
+		headers.XForwardedFor.ShouldBe("192.168.1.1,127.0.0.1");
+		headers.Count.ShouldBe(2);
 	}
 }
 
@@ -271,7 +264,7 @@ public class FluentHttpHeaders_ToHashString
 		};
 		var hash = headers.ToHashString();
 
-		Assert.Equal("Authorization=the-xx&Content-Type=json", hash);
+		hash.ShouldBe("Authorization=the-xx&Content-Type=json");
 	}
 
 	[Fact]
@@ -284,7 +277,7 @@ public class FluentHttpHeaders_ToHashString
 		};
 		var hash = headers.ToHashString();
 
-		Assert.Equal("Authorization=the-xx&Accept=json,msgpack", hash);
+		hash.ShouldBe("Authorization=the-xx&Accept=json,msgpack");
 	}
 
 	[Fact]
@@ -299,6 +292,6 @@ public class FluentHttpHeaders_ToHashString
 			.WithOptions(opts => opts.WithHashingExclude(pair => pair.Key == HeaderTypes.Authorization));
 		var hash = headers.ToHashString();
 
-		Assert.Equal("Accept=json,msgpack&X-Forwarded-Host=sketch7.com", hash);
+		hash.ShouldBe("Accept=json,msgpack&X-Forwarded-Host=sketch7.com");
 	}
 }

--- a/test/FluentHttpRequestBuilderTest.cs
+++ b/test/FluentHttpRequestBuilderTest.cs
@@ -125,7 +125,7 @@ public class RequestBuilder_WithUri
 	public void NullValue_ShouldThrow()
 	{
 		var requestBuilder = GetNewRequestBuilder();
-		Should.Throw<ArgumentNullException>("args", () => requestBuilder.WithUri("{Language}/heroes", new
+		Should.Throw<ArgumentNullException>(() => requestBuilder.WithUri("{Language}/heroes", new
 		{
 			Language = (string?)null
 		}));
@@ -363,7 +363,7 @@ public class RequestBuilder_WithHeaders
 	{
 		var builder = GetNewRequestBuilder()
 				.WithUri("/org/sketch7")
-				.WithHeader("locale", new StringValues(new[] { "mt", "en" }))
+				.WithHeader("locale", new StringValues(["mt", "en"]))
 			;
 		var request = builder.Build();
 
@@ -640,7 +640,7 @@ public class FluentRequest_GetHash
 		{
 			var requestBuilder = GetNewRequestBuilder()
 					.WithRequestHashOptions(opts =>
-						opts.WithHeadersExcludeByKeys(new[] { HeaderTypes.Accept, HeaderTypes.UserAgent }))
+						opts.WithHeadersExcludeByKeys([HeaderTypes.Accept, HeaderTypes.UserAgent]))
 					.WithUri("/api/heroes/azmodan")
 					.WithHeader("local", "en-GB")
 				;

--- a/test/FluentHttpRequestBuilderTest.cs
+++ b/test/FluentHttpRequestBuilderTest.cs
@@ -33,7 +33,7 @@ public class RequestBuilder_Build
 			.CreateRequest()
 			.ReturnAsResponse();
 
-		Assert.Equal("https://sketch7.com/api/heroes/", response.Message.RequestMessage?.RequestUri?.ToString());
+		response.Message.RequestMessage?.RequestUri?.ToString().ShouldBe("https://sketch7.com/api/heroes/");
 	}
 
 	[Fact]
@@ -42,7 +42,7 @@ public class RequestBuilder_Build
 		var request = GetNewRequestBuilder(configureClient: c => c.WithBaseUrl(string.Empty))
 			.Build();
 
-		Assert.Equal("/api", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/api");
 	}
 
 	[Fact]
@@ -56,7 +56,7 @@ public class RequestBuilder_Build
 			.CreateRequest()
 			.ReturnAsResponse();
 
-		Assert.Equal("https://sketch7.com/oauth/token", response.Message.RequestMessage?.RequestUri?.ToString());
+		response.Message.RequestMessage?.RequestUri?.ToString().ShouldBe("https://sketch7.com/oauth/token");
 	}
 
 	[Fact]
@@ -72,7 +72,7 @@ public class RequestBuilder_Build
 			.CreateRequest()
 			.ReturnAsResponse();
 
-		Assert.Equal("https://sketch7.com/oauth/token", response.Message.RequestMessage?.RequestUri?.ToString());
+		response.Message.RequestMessage?.RequestUri?.ToString().ShouldBe("https://sketch7.com/oauth/token");
 	}
 
 	[Fact]
@@ -88,7 +88,7 @@ public class RequestBuilder_Build
 			.CreateRequest()
 			.ReturnAsResponse();
 
-		Assert.Equal("https://sketch7.com/api/heroes/v1/", response.Message.RequestMessage?.RequestUri?.ToString());
+		response.Message.RequestMessage?.RequestUri?.ToString().ShouldBe("https://sketch7.com/api/heroes/v1/");
 	}
 
 	[Fact]
@@ -102,7 +102,7 @@ public class RequestBuilder_Build
 			.WithQueryParams(new { Language = "en" })
 			.ReturnAsResponse();
 
-		Assert.Equal("https://sketch7.com/api/heroes/?language=en", response.Message.RequestMessage?.RequestUri?.ToString());
+		response.Message.RequestMessage?.RequestUri?.ToString().ShouldBe("https://sketch7.com/api/heroes/?language=en");
 	}
 }
 
@@ -118,14 +118,14 @@ public class RequestBuilder_WithUri
 				Hero = "azmodan"
 			}).Build();
 
-		Assert.Equal("en/heroes/azmodan", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("en/heroes/azmodan");
 	}
 
 	[Fact]
 	public void NullValue_ShouldThrow()
 	{
 		var requestBuilder = GetNewRequestBuilder();
-		Assert.Throws<ArgumentNullException>("args", () => requestBuilder.WithUri("{Language}/heroes", new
+		Should.Throw<ArgumentNullException>("args", () => requestBuilder.WithUri("{Language}/heroes", new
 		{
 			Language = (string?)null
 		}));
@@ -145,7 +145,7 @@ public class RequestBuilder_WithQueryParams
 				Filter = "all"
 			}).Build();
 
-		Assert.Equal("/org/sketch7?page=1&filter=all", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/org/sketch7?page=1&filter=all");
 	}
 
 	[Fact]
@@ -159,7 +159,7 @@ public class RequestBuilder_WithQueryParams
 				Filter = "all"
 			}, c => c.WithKeyFormatter(null!)).Build();
 
-		Assert.Equal("/org/sketch7?Page=1&Filter=all", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/org/sketch7?Page=1&Filter=all");
 	}
 
 	[Theory]
@@ -175,7 +175,7 @@ public class RequestBuilder_WithQueryParams
 				filter,
 			}).Build();
 
-		Assert.Equal("/org/sketch7", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/org/sketch7");
 	}
 
 	[Fact]
@@ -190,7 +190,7 @@ public class RequestBuilder_WithQueryParams
 				Page = 1
 			}).Build();
 
-		Assert.Equal("/org/sketch7?page=1", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/org/sketch7?page=1");
 	}
 
 	[Fact]
@@ -204,7 +204,7 @@ public class RequestBuilder_WithQueryParams
 				Filter = "all"
 			}).Build();
 
-		Assert.Equal("/org/sketch7?hero=rex&page=1&filter=all", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/org/sketch7?hero=rex&page=1&filter=all");
 	}
 
 	[Fact]
@@ -215,7 +215,7 @@ public class RequestBuilder_WithQueryParams
 			.WithQueryParams(new { })
 			.Build();
 
-		Assert.Equal("/org/sketch7", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/org/sketch7");
 	}
 
 	[Fact]
@@ -233,7 +233,7 @@ public class RequestBuilder_WithQueryParams
 			.WithQueryParams(qsParams)
 			.Build();
 
-		Assert.Equal("/org/sketch7?role=assassin&class=rogue", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/org/sketch7?role=assassin&class=rogue");
 	}
 
 	[Fact]
@@ -247,7 +247,7 @@ public class RequestBuilder_WithQueryParams
 				Powers = new List<int> { 1337, 2337 }
 			}).Build();
 
-		Assert.Equal("/org/sketch7/heroes?roles=warrior&roles=assassin&powers=1337&powers=2337", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/org/sketch7/heroes?roles=warrior&roles=assassin&powers=1337&powers=2337");
 	}
 
 	[Fact]
@@ -261,7 +261,7 @@ public class RequestBuilder_WithQueryParams
 			}, opts => opts.CollectionMode = QueryStringCollectionMode.CommaSeparated
 			).Build();
 
-		Assert.Equal("/org/sketch7/heroes?roles=warrior,assassin", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/org/sketch7/heroes?roles=warrior,assassin");
 	}
 
 	[Fact]
@@ -276,7 +276,7 @@ public class RequestBuilder_WithQueryParams
 			}, opts => opts.WithKeyFormatter(s => s.ToUpper())
 			).Build();
 
-		Assert.Equal("/org/sketch7/heroes?ROLES=warrior,assassin", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/org/sketch7/heroes?ROLES=warrior,assassin");
 	}
 
 	[Fact]
@@ -297,7 +297,7 @@ public class RequestBuilder_WithQueryParams
 			}
 			).Build();
 
-		Assert.Equal("/org/sketch7/heroes?ROLES=warrior,assassin&POWERS=MEDIUM,HIGH", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/org/sketch7/heroes?ROLES=warrior,assassin&POWERS=MEDIUM,HIGH");
 	}
 
 	[Fact]
@@ -319,7 +319,7 @@ public class RequestBuilder_WithQueryParams
 			}
 			).Build();
 
-		Assert.Equal("/org/sketch7/heroes?role=warrior&power=MEDIUM&dateTime=2025-01-01T00:00:00Z", request.Uri?.ToString());
+		request.Uri?.ToString().ShouldBe("/org/sketch7/heroes?role=warrior&power=MEDIUM&dateTime=2025-01-01T00:00:00Z");
 	}
 }
 
@@ -329,7 +329,7 @@ public class RequestBuilder_BuildValidation
 	public void ThrowsErrorWhenMethodNotSpecified()
 	{
 		var builder = GetNewRequestBuilder();
-		Assert.Throws<RequestValidationException>(() => builder.WithMethod(null!).WithUri("/org").Build());
+		Should.Throw<RequestValidationException>(() => builder.WithMethod(null!).WithUri("/org").Build());
 	}
 
 	[Fact]
@@ -338,7 +338,7 @@ public class RequestBuilder_BuildValidation
 		var requestBuilder = GetNewRequestBuilder()
 			.AsGet()
 			.WithBody(new { Name = "Kaboom!" });
-		Assert.Throws<RequestValidationException>(() => requestBuilder.Build());
+		Should.Throw<RequestValidationException>(() => requestBuilder.Build());
 	}
 }
 
@@ -354,8 +354,8 @@ public class RequestBuilder_WithHeaders
 		var request = builder.Build();
 
 		var header = request.Headers.GetValues("chiko").FirstOrDefault();
-		Assert.NotNull(header);
-		Assert.Equal("hex", header);
+		header.ShouldNotBeNull();
+		header.ShouldBe("hex");
 	}
 
 	[Fact]
@@ -368,12 +368,8 @@ public class RequestBuilder_WithHeaders
 		var request = builder.Build();
 
 		var headers = request.Headers.GetValues("locale");
-		Assert.NotNull(headers);
-		Assert.Collection(
-			headers,
-			x => Assert.Equal("mt", x),
-			x => Assert.Equal("en", x)
-		);
+		headers.ShouldNotBeNull();
+		headers.ShouldBe(["mt", "en"]);
 	}
 
 	[Fact]
@@ -387,8 +383,8 @@ public class RequestBuilder_WithHeaders
 		var request = builder.Build();
 
 		var header = request.Headers.GetValues("chiko").FirstOrDefault();
-		Assert.NotNull(header);
-		Assert.Equal("hexII", header);
+		header.ShouldNotBeNull();
+		header.ShouldBe("hexII");
 	}
 
 	[Fact]
@@ -406,10 +402,10 @@ public class RequestBuilder_WithHeaders
 
 		var chikoHeader = request.Headers.GetValues("chiko").FirstOrDefault();
 		var localeHeader = request.Headers.GetValues("locale").FirstOrDefault();
-		Assert.NotNull(chikoHeader);
-		Assert.Equal("hexII", chikoHeader);
-		Assert.NotNull(localeHeader);
-		Assert.Equal("mt-MT", localeHeader);
+		chikoHeader.ShouldNotBeNull();
+		chikoHeader.ShouldBe("hexII");
+		localeHeader.ShouldNotBeNull();
+		localeHeader.ShouldBe("mt-MT");
 	}
 
 	[Fact]
@@ -427,10 +423,10 @@ public class RequestBuilder_WithHeaders
 
 		var chikoHeader = request.Headers.GetValues("chiko").FirstOrDefault();
 		var localeHeader = request.Headers.GetValues("locale").FirstOrDefault();
-		Assert.NotNull(chikoHeader);
-		Assert.Equal("hexII", chikoHeader);
-		Assert.NotNull(localeHeader);
-		Assert.Equal("mt-MT", localeHeader);
+		chikoHeader.ShouldNotBeNull();
+		chikoHeader.ShouldBe("hexII");
+		localeHeader.ShouldNotBeNull();
+		localeHeader.ShouldBe("mt-MT");
 	}
 
 	[Fact]
@@ -443,8 +439,8 @@ public class RequestBuilder_WithHeaders
 		var request = builder.Build();
 
 		var userAgentHeader = request.Headers.GetValues(HeaderTypes.UserAgent).FirstOrDefault();
-		Assert.NotNull(userAgentHeader);
-		Assert.Equal("fluently", userAgentHeader);
+		userAgentHeader.ShouldNotBeNull();
+		userAgentHeader.ShouldBe("fluently");
 	}
 
 	[Fact]
@@ -458,8 +454,8 @@ public class RequestBuilder_WithHeaders
 		var request = builder.Build();
 
 		var userAgentHeader = request.Headers.GetValues(HeaderTypes.UserAgent).FirstOrDefault();
-		Assert.NotNull(userAgentHeader);
-		Assert.Equal(userAgent, userAgentHeader);
+		userAgentHeader.ShouldNotBeNull();
+		userAgentHeader.ShouldBe(userAgent);
 	}
 }
 
@@ -482,8 +478,8 @@ public class RequestBuilder_Return
 		var response = await httpClient.CreateRequest("/api/heroes/azmodan")
 			.ReturnAsString();
 
-		Assert.NotNull(response);
-		Assert.Equal(mockResponse, response);
+		response.ShouldNotBeNull();
+		response.ShouldBe(mockResponse);
 	}
 }
 
@@ -512,8 +508,8 @@ public class RequestBuilder_PostWithBody
 			.ReturnAsResponse<Hero>();
 
 		response.EnsureSuccessStatusCode();
-		Assert.NotNull(response);
-		Assert.Equal("Lord of Sin", response.Data!.Title);
+		response.ShouldNotBeNull();
+		response.Data!.Title.ShouldBe("Lord of Sin");
 	}
 }
 
@@ -545,12 +541,12 @@ public class RequestBuilder_ReturnMulti
 		var response2 = await requestBuilder.ReturnAsResponse<Hero>();
 
 		response1.EnsureSuccessStatusCode();
-		Assert.NotNull(response1);
-		Assert.Equal("Lord of Sin", response1.Data!.Title);
+		response1.ShouldNotBeNull();
+		response1.Data!.Title.ShouldBe("Lord of Sin");
 
 		response2.EnsureSuccessStatusCode();
-		Assert.NotNull(response2);
-		Assert.Equal("Lord of Sin", response2.Data!.Title);
+		response2.ShouldNotBeNull();
+		response2.Data!.Title.ShouldBe("Lord of Sin");
 	}
 }
 
@@ -577,7 +573,7 @@ public class FluentRequest_GetHash
 		var request1Hash = request1.Build().GetHash();
 		var request2Hash = request2.Build().GetHash();
 
-		Assert.Equal(request1Hash, request2Hash);
+		request1Hash.ShouldBe(request2Hash);
 	}
 
 	[Fact]
@@ -594,14 +590,14 @@ public class FluentRequest_GetHash
 		var requestHashWithHeaders = requestWithHeaders.Build().GetHash();
 		var noTokenRequestHash = requestNoHeaders.Build().GetHash();
 
-		Assert.NotEqual(requestHashWithHeaders, noTokenRequestHash);
+		requestHashWithHeaders.ShouldNotBe(noTokenRequestHash);
 
 		const string requestHashWithHeadersAssert =
 			"method=GET;url=http://local.sketch7.io:5000/api/heroes/azmodan;headers=Accept=application/json,text/json,application/xml,text/xml,application/x-www-form-urlencoded&User-Agent=fluently&locale=en-GB&X-SSV-VERSION=2019.02-2&Authorization=Bearer XXX&local=en-GB;content=";
 		const string noHeadersRequestHashAssert =
 			"method=GET;url=http://local.sketch7.io:5000/api/heroes/azmodan;headers=Accept=application/json,text/json,application/xml,text/xml,application/x-www-form-urlencoded&User-Agent=fluently&locale=en-GB&X-SSV-VERSION=2019.02-2;content=";
-		Assert.Equal(requestHashWithHeadersAssert, requestHashWithHeaders);
-		Assert.Equal(noHeadersRequestHashAssert, noTokenRequestHash);
+		requestHashWithHeaders.ShouldBe(requestHashWithHeadersAssert);
+		noTokenRequestHash.ShouldBe(noHeadersRequestHashAssert);
 	}
 
 	public class WithHashingOptions
@@ -620,7 +616,7 @@ public class FluentRequest_GetHash
 			var hash = requestBuilder.Build().GetHash();
 
 			const string assertHash = "method=GET;url=https://sketch7.com/api/heroes/azmodan;headers=Accept=application/json,text/json,application/xml,text/xml,application/x-www-form-urlencoded&User-Agent=fluently&local=en-GB;content=";
-			Assert.Equal(assertHash, hash);
+			hash.ShouldBe(assertHash);
 		}
 
 		[Fact]
@@ -636,7 +632,7 @@ public class FluentRequest_GetHash
 
 			const string assertHash =
 				"method=GET;url=https://sketch7.com/api/heroes/azmodan;headers=User-Agent=fluently&local=en-GB;content=";
-			Assert.Equal(assertHash, hash);
+			hash.ShouldBe(assertHash);
 		}
 
 		[Fact]
@@ -652,7 +648,7 @@ public class FluentRequest_GetHash
 			var hash = requestBuilder.Build().GetHash();
 
 			const string assertHash = "method=GET;url=https://sketch7.com/api/heroes/azmodan;headers=local=en-GB;content=";
-			Assert.Equal(assertHash, hash);
+			hash.ShouldBe(assertHash);
 		}
 
 		[Fact]
@@ -677,7 +673,7 @@ public class FluentRequest_GetHash
 
 			var hash = requestBuilder.Build().GetHash();
 
-			Assert.Equal("method=GET;url=https://sketch7.com/api/heroes/azmodan;headers=local=en-GB;content=", hash);
+			hash.ShouldBe("method=GET;url=https://sketch7.com/api/heroes/azmodan;headers=local=en-GB;content=");
 		}
 
 		[Fact]
@@ -697,7 +693,7 @@ public class FluentRequest_GetHash
 			var hash = requestBuilder.Build().GetHash();
 
 			const string assertHash = "method=GET;url=https://sketch7.com/api/heroes/azmodan;headers=Accept=application/json,text/json,application/xml,text/xml,application/x-www-form-urlencoded&User-Agent=fluently;content=";
-			Assert.Equal(assertHash, hash);
+			hash.ShouldBe(assertHash);
 		}
 
 		[Fact]
@@ -712,7 +708,7 @@ public class FluentRequest_GetHash
 			var hash = requestBuilder.Build().GetHash();
 
 			const string assertHash = "method=GET;url=https://sketch7.com/api/heroes/azmodan;headers=Accept=application/json,text/json,application/xml,text/xml,application/x-www-form-urlencoded&User-Agent=fluently;content=";
-			Assert.Equal(assertHash, hash);
+			hash.ShouldBe(assertHash);
 		}
 
 		[Fact]
@@ -730,7 +726,7 @@ public class FluentRequest_GetHash
 			var requestHash = requestBuilder.Build().GetHash();
 
 			const string assertHash = "method=POST;url=https://sketch7.com/api/heroes/azmodan;headers=Accept=application/json,text/json,application/xml,text/xml,application/x-www-form-urlencoded&User-Agent=fluently;content={\"email\":\"chiko@sketch7.com\"}";
-			Assert.Equal(assertHash, requestHash);
+			requestHash.ShouldBe(assertHash);
 		}
 
 		[Fact]
@@ -749,7 +745,7 @@ public class FluentRequest_GetHash
 			var hash = requestBuilder.Build().GetHash();
 
 			const string assertHash = "method=POST;url=https://sketch7.com/api/heroes/azmodan;headers=Accept=application/json,text/json,application/xml,text/xml,application/x-www-form-urlencoded&User-Agent=fluently;content=";
-			Assert.Equal(assertHash, hash);
+			hash.ShouldBe(assertHash);
 		}
 	}
 }

--- a/test/FluentlyHttpClient.Test.csproj
+++ b/test/FluentlyHttpClient.Test.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/test/FluentlyHttpClient.Test.csproj
+++ b/test/FluentlyHttpClient.Test.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)..\test.runsettings</RunSettingsFilePath>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
@@ -9,7 +11,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3">
+      <PrivateAssets>buildTransitive</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/GlobalUsings.cs
+++ b/test/GlobalUsings.cs
@@ -1,6 +1,7 @@
 // Global using directives
 
 global using FluentlyHttpClient;
+global using Shouldly;
 global using FluentlyHttpClient.GraphQL;
 global using FluentlyHttpClient.Test;
 global using RichardSzalay.MockHttp;

--- a/test/HttpMiddlewareTest.cs
+++ b/test/HttpMiddlewareTest.cs
@@ -117,7 +117,7 @@ public class HttpMiddlewareTest
 			.Register();
 
 		var httpClient = fluentHttpClientFactory.Get("sketch7");
-		var response = await httpClient.RawHttpClient.GetAsync("/api/heroes/azmodan");
+		var response = await httpClient.RawHttpClient.GetAsync("/api/heroes/azmodan", TestContext.Current.CancellationToken);
 		var brand = response.Headers.GetValues("X-Brand-Id");
 
 		brand.First().ShouldBe("snorlax");
@@ -140,7 +140,7 @@ public class HttpMiddlewareTest
 
 		var httpClient = fluentHttpClientFactory.Get("sketch7");
 
-		var response = await httpClient.RawHttpClient.GetAsync("/api/heroes/azmodan");
+		var response = await httpClient.RawHttpClient.GetAsync("/api/heroes/azmodan", TestContext.Current.CancellationToken);
 		var brand = response.Headers.GetValues("X-Brand-Id");
 		var monster = response.Headers.GetValues("monster");
 

--- a/test/HttpMiddlewareTest.cs
+++ b/test/HttpMiddlewareTest.cs
@@ -70,8 +70,8 @@ public class HttpMiddlewareTest
 		response.Items.TryGetValue("request", out var requestItem);
 		response.Items.TryGetValue("monster", out var monsterItem);
 
-		Assert.Equal("item", requestItem);
-		Assert.Equal("orsachiottolo", monsterItem);
+		requestItem.ShouldBe("item");
+		monsterItem.ShouldBe("orsachiottolo");
 	}
 
 	[Fact]
@@ -97,8 +97,8 @@ public class HttpMiddlewareTest
 		response.Items.TryGetValue("request", out var requestItem);
 		response.Items.TryGetValue("monster", out var monsterItem);
 
-		Assert.Equal("item", requestItem);
-		Assert.Equal("orsachiottolo", monsterItem);
+		requestItem.ShouldBe("item");
+		monsterItem.ShouldBe("orsachiottolo");
 	}
 
 	[Fact]
@@ -120,7 +120,7 @@ public class HttpMiddlewareTest
 		var response = await httpClient.RawHttpClient.GetAsync("/api/heroes/azmodan");
 		var brand = response.Headers.GetValues("X-Brand-Id");
 
-		Assert.Equal("snorlax", brand.First());
+		brand.First().ShouldBe("snorlax");
 	}
 
 	[Fact]
@@ -144,7 +144,7 @@ public class HttpMiddlewareTest
 		var brand = response.Headers.GetValues("X-Brand-Id");
 		var monster = response.Headers.GetValues("monster");
 
-		Assert.Equal("snorlax", brand.First());
-		Assert.Equal("orsachiottolo", monster.First());
+		brand.First().ShouldBe("snorlax");
+		monster.First().ShouldBe("orsachiottolo");
 	}
 }

--- a/test/HttpResponseSerializerTest.cs
+++ b/test/HttpResponseSerializerTest.cs
@@ -6,7 +6,7 @@ namespace FluentlyHttpClient.Test;
 public class HttpResponseSerializerTest
 {
 	//[Fact]
-	public async void ShouldBeSerialized()
+	public async Task ShouldBeSerialized()
 	{
 		var mockHttp = new MockHttpMessageHandler();
 		mockHttp.When(HttpMethod.Post, "http://local.sketch7.io:5000/api/heroes/azmodan")

--- a/test/Integration/FileUploadIntegrationTest.cs
+++ b/test/Integration/FileUploadIntegrationTest.cs
@@ -40,10 +40,10 @@ public class FileUploadIntegrationTest(SampleApiFactory factory) : IClassFixture
 			.WithBodyContent(multiForm)
 			.ReturnAsResponse<UploadResult>();
 
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-		Assert.Equal("animal-mustache.jpg", response.Data!.FileName);
-		Assert.Equal("image/jpeg", response.Data!.ContentType);
-		Assert.Equal(3.96875, response.Data!.Size);
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		response.Data!.FileName.ShouldBe("animal-mustache.jpg");
+		response.Data!.ContentType.ShouldBe("image/jpeg");
+		response.Data!.Size.ShouldBe(3.96875);
 	}
 
 	[Fact]
@@ -64,10 +64,10 @@ public class FileUploadIntegrationTest(SampleApiFactory factory) : IClassFixture
 			.WithBodyContent(multiForm)
 			.ReturnAsResponse<UploadResult>();
 
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-		Assert.Equal("animal-mustache.jpg", response.Data!.FileName);
-		Assert.Equal("image/jpeg", response.Data!.ContentType);
-		Assert.Equal(3.96875, response.Data!.Size);
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		response.Data!.FileName.ShouldBe("animal-mustache.jpg");
+		response.Data!.ContentType.ShouldBe("image/jpeg");
+		response.Data!.Size.ShouldBe(3.96875);
 	}
 
 	[Fact]
@@ -89,9 +89,9 @@ public class FileUploadIntegrationTest(SampleApiFactory factory) : IClassFixture
 			.WithBodyContent(multiForm)
 			.ReturnAsResponse<UploadResult>();
 
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-		Assert.Equal("animal-mustache.jpg", response.Data!.FileName);
-		Assert.Equal("image/jpeg", response.Data!.ContentType);
-		Assert.Equal(3.96875, response.Data!.Size);
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		response.Data!.FileName.ShouldBe("animal-mustache.jpg");
+		response.Data!.ContentType.ShouldBe("image/jpeg");
+		response.Data!.Size.ShouldBe(3.96875);
 	}
 }

--- a/test/Integration/MessagePackIntegrationTest.cs
+++ b/test/Integration/MessagePackIntegrationTest.cs
@@ -18,10 +18,10 @@ public class MessagePackIntegrationTest(SampleApiFactory factory) : IClassFixtur
 		var response = await httpClient.CreateRequest("/api/heroes/azmodan")
 			.ReturnAsResponse<Hero>();
 
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-		Assert.Equal("azmodan", response.Data!.Key);
-		Assert.Equal("Azmodan", response.Data!.Name);
-		Assert.Equal("Lord of Sin", response.Data!.Title);
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		response.Data!.Key.ShouldBe("azmodan");
+		response.Data!.Name.ShouldBe("Azmodan");
+		response.Data!.Title.ShouldBe("Lord of Sin");
 	}
 
 	[Fact]
@@ -42,9 +42,9 @@ public class MessagePackIntegrationTest(SampleApiFactory factory) : IClassFixtur
 			})
 			.ReturnAsResponse<Hero>();
 
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-		Assert.Equal("valeera", response.Data!.Key);
-		Assert.Equal("Valeera", response.Data!.Name);
-		Assert.Equal("Shadow of the Uncrowned", response.Data!.Title);
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		response.Data!.Key.ShouldBe("valeera");
+		response.Data!.Name.ShouldBe("Valeera");
+		response.Data!.Title.ShouldBe("Shadow of the Uncrowned");
 	}
 }

--- a/test/Integration/ResponseCacheIntegrationTest.cs
+++ b/test/Integration/ResponseCacheIntegrationTest.cs
@@ -35,23 +35,23 @@ public class ResponseCacheIntegrationTest(SampleApiFactory factory) : IClassFixt
 
 		var responseReason = response.ReasonPhrase;
 
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-		Assert.Equal("azmodan", response.Data!.Key);
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		response.Data!.Key.ShouldBe("azmodan");
 
 		response = await httpClient.CreateRequest("/api/heroes/azmodan")
 			.ReturnAsResponse<Hero>();
 
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-		Assert.Equal("azmodan", response.Data!.Key);
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		response.Data!.Key.ShouldBe("azmodan");
 
 		response = await httpClient.CreateRequest("/api/heroes/azmodan")
 			.ReturnAsResponse<Hero>();
 
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-		Assert.Equal("azmodan", response.Data!.Key);
-		Assert.Equal("Azmodan", response.Data!.Name);
-		Assert.Equal("Lord of Sin", response.Data!.Title);
-		Assert.Equal(responseReason, response.ReasonPhrase);
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		response.Data!.Key.ShouldBe("azmodan");
+		response.Data!.Name.ShouldBe("Azmodan");
+		response.Data!.Title.ShouldBe("Lord of Sin");
+		response.ReasonPhrase.ShouldBe(responseReason);
 	}
 
 	[Fact]
@@ -80,24 +80,24 @@ public class ResponseCacheIntegrationTest(SampleApiFactory factory) : IClassFixt
 
 		var responseReason = response.ReasonPhrase;
 
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-		Assert.Equal("azmodan", response.Data!.Key);
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		response.Data!.Key.ShouldBe("azmodan");
 
 		response = await httpClient.CreateRequest("/api/heroes/azmodan")
 			.ReturnAsResponse<Hero>();
 
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-		Assert.Equal("azmodan", response.Data!.Key);
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		response.Data!.Key.ShouldBe("azmodan");
 
 		response = await httpClient.CreateRequest("/api/heroes/azmodan")
 			.ReturnAsResponse<Hero>();
 
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-		Assert.Equal("azmodan", response.Data!.Key);
-		Assert.Equal("Azmodan", response.Data!.Name);
-		Assert.Equal("Lord of Sin", response.Data!.Title);
-		Assert.Equal("Kestrel", response.Headers.Server.ToString());
-		Assert.Equal(responseReason, response.ReasonPhrase);
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
+		response.Data!.Key.ShouldBe("azmodan");
+		response.Data!.Name.ShouldBe("Azmodan");
+		response.Data!.Title.ShouldBe("Lord of Sin");
+		response.Headers.Server.ToString().ShouldBe("Kestrel");
+		response.ReasonPhrase.ShouldBe(responseReason);
 
 		//Assert.Equal(HttpStatusCode.OK, response.Headers.);
 	}

--- a/test/Integration/SerilogIntegrationTest.cs
+++ b/test/Integration/SerilogIntegrationTest.cs
@@ -55,7 +55,7 @@ public class SerilogIntegrationTest
 			})
 			.Return<Hero>();
 
-		Assert.NotNull(hero);
-		Assert.Equal("Azmodan", hero.Name);
+		hero.ShouldNotBeNull();
+		hero.Name.ShouldBe("Azmodan");
 	}
 }

--- a/test/LoggingHttpMiddlewareTest.cs
+++ b/test/LoggingHttpMiddlewareTest.cs
@@ -112,8 +112,8 @@ public class LoggingHttpMiddlewareTest
 		var options = request.GetLoggingOptions(loggerHttpMiddlewareOptions);
 
 		options.ShouldNotBeNull();
-		options.ShouldLogDetailedRequest.ShouldBeTrue();
-		options.ShouldLogDetailedResponse.ShouldBeTrue();
+		options.ShouldLogDetailedRequest.ShouldBe(true);
+		options.ShouldLogDetailedResponse.ShouldBe(true);
 	}
 
 	[Fact]
@@ -141,8 +141,8 @@ public class LoggingHttpMiddlewareTest
 		var options = request.GetLoggingOptions(loggerHttpMiddlewareOptions);
 
 		options.ShouldNotBeNull();
-		options.ShouldLogDetailedRequest.ShouldBeTrue();
-		options.ShouldLogDetailedResponse.ShouldBeTrue();
+		options.ShouldLogDetailedRequest.ShouldBe(true);
+		options.ShouldLogDetailedResponse.ShouldBe(true);
 	}
 
 	[Fact]
@@ -170,7 +170,7 @@ public class LoggingHttpMiddlewareTest
 		var options = request.GetLoggingOptions(loggerHttpMiddlewareOptions);
 
 		options.ShouldNotBeNull();
-		options.ShouldLogDetailedRequest.ShouldBeTrue();
-		options.ShouldLogDetailedResponse.ShouldBeTrue();
+		options.ShouldLogDetailedRequest.ShouldBe(true);
+		options.ShouldLogDetailedResponse.ShouldBe(true);
 	}
 }

--- a/test/LoggingHttpMiddlewareTest.cs
+++ b/test/LoggingHttpMiddlewareTest.cs
@@ -26,8 +26,8 @@ public class LoggingHttpMiddlewareTest
 
 		var hero = await httpClient.Get<Hero>("/api/heroes/azmodan");
 
-		Assert.NotNull(hero);
-		Assert.Equal("Azmodan", hero.Name);
+		hero.ShouldNotBeNull();
+		hero.Name.ShouldBe("Azmodan");
 	}
 
 	[Fact]
@@ -57,8 +57,8 @@ public class LoggingHttpMiddlewareTest
 			})
 			.ReturnAsResponse();
 
-		Assert.NotNull(response);
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		response.ShouldNotBeNull();
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
 	}
 
 	[Fact]
@@ -88,8 +88,8 @@ public class LoggingHttpMiddlewareTest
 			})
 			.ReturnAsResponse();
 
-		Assert.NotNull(response);
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		response.ShouldNotBeNull();
+		response.StatusCode.ShouldBe(HttpStatusCode.OK);
 	}
 
 	[Fact]
@@ -111,9 +111,9 @@ public class LoggingHttpMiddlewareTest
 
 		var options = request.GetLoggingOptions(loggerHttpMiddlewareOptions);
 
-		Assert.NotNull(options);
-		Assert.True(options.ShouldLogDetailedRequest);
-		Assert.True(options.ShouldLogDetailedResponse);
+		options.ShouldNotBeNull();
+		options.ShouldLogDetailedRequest.ShouldBeTrue();
+		options.ShouldLogDetailedResponse.ShouldBeTrue();
 	}
 
 	[Fact]
@@ -140,9 +140,9 @@ public class LoggingHttpMiddlewareTest
 
 		var options = request.GetLoggingOptions(loggerHttpMiddlewareOptions);
 
-		Assert.NotNull(options);
-		Assert.True(options.ShouldLogDetailedRequest);
-		Assert.True(options.ShouldLogDetailedResponse);
+		options.ShouldNotBeNull();
+		options.ShouldLogDetailedRequest.ShouldBeTrue();
+		options.ShouldLogDetailedResponse.ShouldBeTrue();
 	}
 
 	[Fact]
@@ -169,8 +169,8 @@ public class LoggingHttpMiddlewareTest
 
 		var options = request.GetLoggingOptions(loggerHttpMiddlewareOptions);
 
-		Assert.NotNull(options);
-		Assert.True(options.ShouldLogDetailedRequest);
-		Assert.True(options.ShouldLogDetailedResponse);
+		options.ShouldNotBeNull();
+		options.ShouldLogDetailedRequest.ShouldBeTrue();
+		options.ShouldLogDetailedResponse.ShouldBeTrue();
 	}
 }

--- a/test/TimerHttpMiddlewareTest.cs
+++ b/test/TimerHttpMiddlewareTest.cs
@@ -20,9 +20,9 @@ public class TimerHttpMiddlewareTest
 		var response = await httpClient.CreateRequest("/api/heroes/azmodan")
 			.ReturnAsResponse<Hero>();
 
-		Assert.NotNull(response.Data);
-		Assert.Equal("Azmodan", response.Data.Name);
-		Assert.NotEqual(TimeSpan.Zero, response.GetTimeTaken());
+		response.Data.ShouldNotBeNull();
+		response.Data.Name.ShouldBe("Azmodan");
+		response.GetTimeTaken().ShouldNotBe(TimeSpan.Zero);
 	}
 
 	[Fact]
@@ -42,8 +42,8 @@ public class TimerHttpMiddlewareTest
 			.WithTimerWarnThreshold(TimeSpan.FromSeconds(1))
 			.ReturnAsResponse<Hero>();
 
-		Assert.NotNull(response.Data);
-		Assert.NotEqual(TimeSpan.Zero, response.GetTimeTaken());
+		response.Data.ShouldNotBeNull();
+		response.GetTimeTaken().ShouldNotBe(TimeSpan.Zero);
 	}
 
 	[Fact]
@@ -56,6 +56,6 @@ public class TimerHttpMiddlewareTest
 				x.WarnThreshold = TimeSpan.Zero;
 			});
 
-		Assert.Throws<ArgumentException>(() => httpClientBuilder.Build());
+		Should.Throw<ArgumentException>(() => httpClientBuilder.Build());
 	}
 }


### PR DESCRIPTION
Refactor tests to utilize Shouldly for assertions, enhancing readability and consistency across various test files. Update test dependencies to include Shouldly.